### PR TITLE
Updates for new releases: 2.4.3 and 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>ng-flow</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <name>ng-flow</name>
     <description>WebJar for ng-flow</description>
     <url>http://webjars.org</url>
@@ -53,7 +53,7 @@
         <url>http://github.com/webjars/ng-flow</url>
         <connection>scm:git:https://github.com/webjars/ng-flow.git</connection>
         <developerConnection>scm:git:https://github.com/webjars/ng-flow.git</developerConnection>
-        <tag>ng-flow-2.5.1</tag>
+        <tag>HEAD</tag>
     </scm>
     
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>ng-flow</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.3</version>
     <name>ng-flow</name>
     <description>WebJar for ng-flow</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>2.4.0</upstream.version>
+        <upstream.version>2.4.3</upstream.version>
         <upstream.url>https://raw.githubusercontent.com/flowjs/ng-flow/v${upstream.version}/dist</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>
@@ -53,7 +53,7 @@
         <url>http://github.com/webjars/ng-flow</url>
         <connection>scm:git:https://github.com/webjars/ng-flow.git</connection>
         <developerConnection>scm:git:https://github.com/webjars/ng-flow.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>ng-flow-2.4.3</tag>
     </scm>
     
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>ng-flow</artifactId>
-    <version>2.4.3</version>
+    <version>2.5.1</version>
     <name>ng-flow</name>
     <description>WebJar for ng-flow</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>2.4.3</upstream.version>
+        <upstream.version>2.5.1</upstream.version>
         <upstream.url>https://raw.githubusercontent.com/flowjs/ng-flow/v${upstream.version}/dist</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>
@@ -53,7 +53,7 @@
         <url>http://github.com/webjars/ng-flow</url>
         <connection>scm:git:https://github.com/webjars/ng-flow.git</connection>
         <developerConnection>scm:git:https://github.com/webjars/ng-flow.git</developerConnection>
-        <tag>ng-flow-2.4.3</tag>
+        <tag>ng-flow-2.5.1</tag>
     </scm>
     
     <dependencies>


### PR DESCRIPTION
Includes tags for both.  (I suspect there's some more automated way to do this, so really this is just a request for webjars for upstream's 2.4.3 and 2.5.1.)
